### PR TITLE
Converted JFrame to JDialog to remove taskbar icons for Notifications

### DIFF
--- a/src/net/hearthstats/Notification.java
+++ b/src/net/hearthstats/Notification.java
@@ -19,13 +19,13 @@ import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JComponent;
-import javax.swing.JFrame;
+import javax.swing.JDialog;
 import javax.swing.JLabel;
 import javax.swing.WindowConstants;
 
 public class Notification {
 
-	public JFrame frame = new JFrame();
+	public JDialog frame = new JDialog();
 	public Notification(String header, String message) {
 		
 		frame.setSize(200, 75);


### PR DESCRIPTION
In theory this should take care of dropping taskbar references for the notifications. I've been unable to cleanly test it locally due to the improper setup for building so I would suggest you double check the results to be safe, but it _should_ be all that is needed to do such a simple conversion.
