### PR TITLE
Add feature to disable all pop-up notifications.

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -6,6 +6,7 @@ check = true
 auto = true
 
 [notifications]
+disableAllNotifications = false
 hsfound = true
 hsclosed = true
 screen = true

--- a/src/net/hearthstats/Config.java
+++ b/src/net/hearthstats/Config.java
@@ -77,6 +77,10 @@ public class Config {
 		return _getIni().get("notifications", "hsclosed").toString().matches("true");
 	}
 	
+	public static boolean disableAllNotifications() {
+		return _getIni().get("notifications", "disableAllNotifications").toString().matches("true");
+	}
+	
 	public static String getVersion() {
 		if(_version == null) {
 			_version = "";

--- a/src/net/hearthstats/Monitor.java
+++ b/src/net/hearthstats/Monitor.java
@@ -232,8 +232,10 @@ public class Monitor extends JFrame implements Observer {
 	}
 
 	protected void _notify(String header, String message) {
+		if (Config.disableAllNotifications())	//Notifications disabled
+			return;
+		
 		_notificationQueue.add(new net.hearthstats.Notification(header, message));
-
 	}
 
 	protected void _updateTitle() {


### PR DESCRIPTION
New configuration property - disableAllNotifications. When set to true,
no pop up notifications will show up when running.
