### PR TITLE
Implemented support for full-screen mode on Mac OS X

### DIFF
--- a/src/jna/osx/CoreGraphicsLibrary.java
+++ b/src/jna/osx/CoreGraphicsLibrary.java
@@ -30,7 +30,12 @@ public interface CoreGraphicsLibrary extends Library {
 
     final static NSString kCGWindowNumber =  NSString.getGlobalString("kCGWindowNumber");
     final static NSString kCGWindowOwnerPID =  NSString.getGlobalString("kCGWindowOwnerPID");
-    final static NSString kCGWindowOwnerName =  NSString.getGlobalString("kCGWindowOwnerName");
+    final static NSString kCGWindowBounds =  NSString.getGlobalString("kCGWindowBounds");
+    final static NSString kCGWindowSharingState =  NSString.getGlobalString("kCGWindowSharingState");
+    final static NSString kCGWindowAlpha =  NSString.getGlobalString("kCGWindowAlpha");
+    final static NSString kCGWindowLayer =  NSString.getGlobalString("kCGWindowLayer");
+    final static NSString kCGWindowIsOnscreen =  NSString.getGlobalString("kCGWindowIsOnscreen");
+    final static NSString kCGWindowName =  NSString.getGlobalString("kCGWindowName");
 
     public static final int kCGWindowListOptionAll = 0;
     public static final int kCGWindowListOptionOnScreenOnly = (1 << 0);

--- a/src/net/hearthstats/Monitor.java
+++ b/src/net/hearthstats/Monitor.java
@@ -127,8 +127,13 @@ public class Monitor extends JFrame implements Observer, WindowListener {
 	private void _showWelcomeLog() {
 		_log("<strong>HearthStats.net Uploader v" + Config.getVersionWithOs() + "</strong>\n");
 		_log("1 - Set your deck slots on the \"Decks\" tab");
-		_log("2 - Run Hearthstone in <strong>WINDOWED</strong> mode");
-		_log("3 - Look for event notifications in this log and bottom right of screen");
+        if (Config.os == Config.OS.OSX) {
+            _log("2 - Run Hearthstone in windowed or full-screen mode");
+            _log("3 - Look for event notifications in this log and bottom right of screen (windowed mode only)");
+        } else {
+            _log("2 - Run Hearthstone in <strong>WINDOWED</strong> mode");
+            _log("3 - Look for event notifications in this log and bottom right of screen");
+        }
 		_log("4 - <a href=\"http://goo.gl/lMbdzg\">Submit feedback here</a> (please copy and paste this log)\n");
 	}
 	


### PR DESCRIPTION
Implemented support for monitoring Hearthstone in both windowed _and_
full-screen mode on OS X. Improved window detection means that
monitoring should continue no matter how many times you change
resolution or switch between windowed and full-screen mode.

Note that this change only works for OS X — it has no impact on Windows
which still supports windowed mode only.
