### PR TITLE
maven Release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<groupId>net.hearthstats</groupId>
 	<artifactId>uploader-parent</artifactId>
 	<name>HearthStats.net Uploader</name>
-	<version>0.17.6</version>	<packaging>pom</packaging>
+	<version>0.17.7-SNAPSHOT</version>	<packaging>pom</packaging>
 
 	<properties>
 		<product.name>HearthStats.net Uploader (parent pom)</product.name>
@@ -25,7 +25,7 @@
 	<scm>
                 <connection>scm:git:https://github.com/HearthStats/HearthStats.net-Uploader.git</connection>
                 <developerConnection>scm:git:https://github.com/tyrcho/HearthStats.net-Uploader.git</developerConnection>
-	  <tag>v0.17.6</tag>
+	  <tag>HEAD</tag>
   </scm>
 
 

--- a/uploader-osx/pom.xml
+++ b/uploader-osx/pom.xml
@@ -5,7 +5,7 @@
 
 	<parent>
 		<groupId>net.hearthstats</groupId>
-		<version>0.17.6</version>		<artifactId>uploader-parent</artifactId>
+		<version>0.17.7-SNAPSHOT</version>		<artifactId>uploader-parent</artifactId>
 	</parent>
 
 	<artifactId>uploader-osx</artifactId>

--- a/uploader-win/pom.xml
+++ b/uploader-win/pom.xml
@@ -5,7 +5,7 @@
 
 	<parent>
 		<groupId>net.hearthstats</groupId>
-		<version>0.17.6</version>		<artifactId>uploader-parent</artifactId>
+		<version>0.17.7-SNAPSHOT</version>		<artifactId>uploader-parent</artifactId>
 	</parent>
 
 	<artifactId>uploader-win</artifactId>

--- a/uploader/pom.xml
+++ b/uploader/pom.xml
@@ -5,7 +5,7 @@
 
 	<parent>
 		<groupId>net.hearthstats</groupId>
-		<version>0.17.6</version>		<artifactId>uploader-parent</artifactId>
+		<version>0.17.7-SNAPSHOT</version>		<artifactId>uploader-parent</artifactId>
 	</parent>
 	<artifactId>uploader</artifactId>
 


### PR DESCRIPTION
I have updated the maven build so we are able to use mvn release successfully now.

This command worked for me :
`mvn release:prepare -Darguments="-DskipTests -P windows"`

We now have 2 additional profiles in the parent pom in order to build only windows or only macos (I could not build the macos project from my windows machine). The default profile is still to build all modules.

Note that mvn release:prepare expects the project to be on a SNAPSHOT revision
