### PR TITLE
Reduced memory usage, especially on Windows 8

### DIFF
--- a/uploader-win/pom.xml
+++ b/uploader-win/pom.xml
@@ -101,7 +101,7 @@
 								<minVersion>1.7.0</minVersion>
 								<opts>
 									<opt>-Xms96m</opt>
-									<opt>-Xmx384m</opt>
+									<opt>-Xmx320m</opt>
 								</opts>
 							</jre>
 							<versionInfo>

--- a/uploader/src/main/scala/net/hearthstats/analysis/HearthstoneAnalyser.scala
+++ b/uploader/src/main/scala/net/hearthstats/analysis/HearthstoneAnalyser.scala
@@ -55,8 +55,6 @@ object HearthstoneAnalyser extends Observable with Logging {
   private val opponentNameUnrankedOcr = new OpponentNameUnrankedOcr
   private val rankLevelOcr = new RankLevelOcr
 
-  private var lastImage: BufferedImage = _
-
   var screen: Screen = null
 
   var isNewArena: Boolean = false
@@ -84,9 +82,6 @@ object HearthstoneAnalyser extends Observable with Logging {
   private var iterationsSinceOpponentTurn: Int = 0
 
   def analyze(image: BufferedImage) {
-    if (lastImage != null)
-      lastImage.flush()
-    lastImage = image
     val matchedScreen =
       if (iterationsSinceScreenMatched < 10) screenAnalyser.identifyScreen(image, screen)
       else screenAnalyser.identifyScreen(image, null)


### PR DESCRIPTION
Reintroduced the forced garbage collection to fix out-of-control memory usage on Windows 8. Every three seconds the monitor loop will now run a garbage collection instead of sleeping the thread. This has the effect of preventing the memory usage from compounding over time... without this forced GC it was common to see Windows allocating all available system memory to the uploader after a period of time, even though the number and size of Java objects was small and fairly constant. It's not apparent why forcing the GC is necessary but on my test Windows 8.1 it does seem to have completely fixed the problem.

See #343 and #380 for more details. This should fix the various problems people have reported with memory usage such as #279, #281, #305, #330, #354, #428, #433, but I will test some more to make sure before releasing.
