### PR TITLE
Link match review and add Entity creation handling in logs

### DIFF
--- a/companion/src/main/scala/net/hearthstats/core/HearthstoneMatch.scala
+++ b/companion/src/main/scala/net/hearthstats/core/HearthstoneMatch.scala
@@ -89,6 +89,9 @@ case class HearthstoneMatch(mode: GameMode = GameMode.UNDETECTED,
     s"http://hearthstats.net/$m/$id/edit"
   }
 
+  def matchUrl: String = {
+    s"http://hearthstats.net/matches/$id"
+  }
   //methods to update the match (return an updated copy)
 
   def withDeck(d: Deck) = copy(deck = Some(d))

--- a/companion/src/main/scala/net/hearthstats/hstatsapi/MatchUtils.scala
+++ b/companion/src/main/scala/net/hearthstats/hstatsapi/MatchUtils.scala
@@ -118,7 +118,7 @@ class MatchUtils(
       case Some(id) =>
         matchState.submitted = true
         val submittedMatch = hsMatch.copy(id = id)
-        uiLog.info(s"Success. <a href='${submittedMatch.editUrl}'>Edit match #$id on HearthStats.net</a>")
+        uiLog.info(s"Success. <a href='${submittedMatch.matchUrl}'>Review match on HearthStats.net</a>")
         hsPresenter.matchSubmitted(submittedMatch, describeMatch(submittedMatch))
         Some(submittedMatch)
       case None =>


### PR DESCRIPTION
- added matchURL (using this instead of editURL) to match
- handle creation log as "entity creation" in analyzeEntity in LogParser
