### PR TITLE
Added option and minor fixes

### DIFF
--- a/companion/src/main/scala/net/hearthstats/config/UserConfig.scala
+++ b/companion/src/main/scala/net/hearthstats/config/UserConfig.scala
@@ -37,8 +37,8 @@ class UserConfig extends Logging with Implicits {
   val recordVideo = config("video.record", true)
   val recordedVideoFolder = config("video.folder", System.getenv("HOME") + "/hearthstats/videos")
   def videoFps = 1000.0 / pollingDelayMs
-  val videoWidth = config("video.width", 2000)
-  val videoHeight = config("video.height", 2000)
+  val videoWidth = config("video.width", 1920)
+  val videoHeight = config("video.height", 1080)
 
   val uploadVideo = config("video.upload", true)
 

--- a/companion/src/main/scala/net/hearthstats/config/UserConfig.scala
+++ b/companion/src/main/scala/net/hearthstats/config/UserConfig.scala
@@ -38,7 +38,7 @@ class UserConfig extends Logging with Implicits {
   val recordedVideoFolder = config("video.folder", System.getenv("HOME") + "/hearthstats/videos")
   def videoFps = 1000.0 / pollingDelayMs
   val videoWidth = config("video.width", 2000)
-  val videoHeight = config("video.fps", 2000)
+  val videoHeight = config("video.height", 2000)
 
   val uploadVideo = config("video.upload", true)
 

--- a/companion/src/main/scala/net/hearthstats/config/UserConfig.scala
+++ b/companion/src/main/scala/net/hearthstats/config/UserConfig.scala
@@ -39,7 +39,8 @@ class UserConfig extends Logging with Implicits {
   def videoFps = 1000.0 / pollingDelayMs
   val videoWidth = config("video.width", 1920)
   val videoHeight = config("video.height", 1080)
-
+  
+  val disableUpload = config("upload.disable", false)
   val uploadVideo = config("video.upload", true)
 
   val gameLanguage = enumConfig("option.gamelanguage", SupportedGameLanguage.EN)

--- a/companion/src/main/scala/net/hearthstats/ui/OptionsPanel.scala
+++ b/companion/src/main/scala/net/hearthstats/ui/OptionsPanel.scala
@@ -111,6 +111,9 @@ class OptionsPanel(
 
     addLabel(t("options.label.video.height") + " ")
     add(new IntOptionTextField(videoHeight), "wrap")
+	
+    addLabel(t("options.label.upload.disable") + " ")
+    addCheckBox(t("options.ui.upload.disable"), disableUpload, disableUpload.set)
   }
 
   // Minimize to System Tray


### PR DESCRIPTION
- Fixed typo of video.fps to video.height for the videoHeight config preference
- Changed default value of video capture resolution to 1920x1080 because nobody uses a 1:1 aspect ratio
- Added option to disable pop-up at the end of each match because it is annoying to the user if they do not have premium. Since free users can't upload anyways, there is no point in asking them if they want to.