### PR TITLE
pad seconds of game duration to 2 places

### DIFF
--- a/companion/src/main/scala/net/hearthstats/hstatsapi/MatchUtils.scala
+++ b/companion/src/main/scala/net/hearthstats/hstatsapi/MatchUtils.scala
@@ -123,7 +123,7 @@ class MatchUtils(
     val describeDuration = {
       val minutes = duration / 60
       val seconds = duration % 60
-      t("match.end.duration", minutes, seconds)
+      t("match.end.duration", minutes, f"$seconds%02d")
     }
 
     s"$describeMode $describeCoin $describePlayers $describeResult $describeDeck $describeTurns $describeDuration"


### PR DESCRIPTION
Game duration has been displayed as 5:6 instead of 5:06. Added padding to two places to fix this.
